### PR TITLE
fix linear scalar math

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ name = "calc-rs"
 version = "0.0.1"
 dependencies = [
  "anybuf 1.0.0",
+ "calc-rs-test",
  "chrono",
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/packages/calc-rs/Cargo.toml
+++ b/packages/calc-rs/Cargo.toml
@@ -19,3 +19,6 @@ cw-storage-plus = { workspace = true }
 prost = { workspace = true }
 rujira-rs = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+calc-rs-test = { workspace = true }

--- a/packages/calc-rs/src/actions/swaps/swap.rs
+++ b/packages/calc-rs/src/actions/swaps/swap.rs
@@ -1,4 +1,7 @@
-use std::mem::discriminant;
+use std::{
+    cmp::{max, min},
+    mem::discriminant,
+};
 
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Coin, CosmosMsg, Decimal, Deps, Env, StdError, StdResult, Uint128};
@@ -25,62 +28,27 @@ pub enum SwapRoute {
     Thorchain(ThorchainRoute),
 }
 
-#[cw_serde]
-pub struct New;
-
-#[cw_serde]
-pub struct Adjusted;
-
-#[cw_serde]
-pub struct Executable {
-    pub expected_amount_out: Coin,
-}
-
-pub trait Quotable {
-    fn validate(&self, deps: Deps, route: &SwapQuote<New>) -> StdResult<()>;
-    fn adjust(
-        &self,
-        deps: Deps,
-        env: &Env,
-        route: SwapQuote<New>,
-    ) -> StdResult<SwapQuote<Adjusted>>;
-    fn validate_adjusted(
-        &self,
-        deps: Deps,
-        env: &Env,
-        route: SwapQuote<Adjusted>,
-    ) -> StdResult<SwapQuote<Executable>>;
-    fn execute(
-        &self,
-        deps: Deps,
-        env: &Env,
-        swap_amount: Coin,
-        minimum_receive_amount: Coin,
-    ) -> StdResult<CosmosMsg>;
-}
-
-impl Quotable for SwapRoute {
-    fn validate(&self, deps: Deps, quote: &SwapQuote<New>) -> StdResult<()> {
+impl SwapRoute {
+    pub fn validate(&self, deps: Deps, quote: &SwapQuote<New>) -> StdResult<()> {
         match self {
             SwapRoute::Fin(route) => route.validate(deps, quote),
             SwapRoute::Thorchain(route) => route.validate(deps, quote),
         }
     }
 
-    fn adjust(
+    pub fn get_expected_amount_out(
         &self,
         deps: Deps,
-        env: &Env,
-        quote: SwapQuote<New>,
-    ) -> StdResult<SwapQuote<Adjusted>> {
+        quote: &SwapQuote<New>,
+    ) -> StdResult<Uint128> {
         match self {
-            SwapRoute::Fin(pair_address) => pair_address.adjust(deps, env, quote),
-            SwapRoute::Thorchain(route) => route.adjust(deps, env, quote),
+            SwapRoute::Fin(route) => route.get_expected_amount_out(deps, quote),
+            SwapRoute::Thorchain(route) => route.get_expected_amount_out(deps, quote),
         }
     }
 
-    fn validate_adjusted(
-        &self,
+    pub fn validate_adjusted(
+        self,
         deps: Deps,
         env: &Env,
         quote: SwapQuote<Adjusted>,
@@ -91,12 +59,12 @@ impl Quotable for SwapRoute {
         }
     }
 
-    fn execute(
+    pub fn execute(
         &self,
         deps: Deps,
         env: &Env,
-        swap_amount: Coin,
-        minimum_receive_amount: Coin,
+        swap_amount: &Coin,
+        minimum_receive_amount: &Coin,
     ) -> StdResult<CosmosMsg> {
         match self {
             SwapRoute::Fin(route) => route.execute(deps, env, swap_amount, minimum_receive_amount),
@@ -105,6 +73,17 @@ impl Quotable for SwapRoute {
             }
         }
     }
+}
+
+#[cw_serde]
+pub struct New;
+
+#[cw_serde]
+pub struct Adjusted;
+
+#[cw_serde]
+pub struct Executable {
+    pub expected_amount_out: Coin,
 }
 
 #[cw_serde]
@@ -123,7 +102,99 @@ impl SwapQuote<New> {
     }
 
     pub fn adjust(self, deps: Deps, env: &Env) -> StdResult<SwapQuote<Adjusted>> {
-        self.route.clone().adjust(deps, env, self)
+        let swap_balance = deps
+            .querier
+            .query_balance(&env.contract.address, &self.swap_amount.denom)?;
+
+        let swap_amount = Coin::new(
+            min(swap_balance.amount, self.swap_amount.amount),
+            self.swap_amount.denom.clone(),
+        );
+
+        if swap_amount.amount.is_zero() {
+            return Err(StdError::generic_err(
+                "Available swap amount is zero".to_string(),
+            ));
+        }
+
+        let (new_swap_amount, new_minimum_receive_amount) = match &self.adjustment {
+            SwapAmountAdjustment::Fixed => {
+                let minimum_receive_amount =
+                    self.minimum_receive_amount
+                        .amount
+                        .mul_floor(Decimal::from_ratio(
+                            swap_amount.amount,
+                            self.swap_amount.amount,
+                        ));
+
+                (swap_amount, minimum_receive_amount)
+            }
+            SwapAmountAdjustment::LinearScalar {
+                base_receive_amount,
+                minimum_swap_amount,
+                scalar,
+            } => {
+                let expected_amount_out = self.route.get_expected_amount_out(deps, &self)?;
+
+                let base_price =
+                    Decimal::from_ratio(self.swap_amount.amount, base_receive_amount.amount);
+
+                let current_price = Decimal::from_ratio(swap_amount.amount, expected_amount_out);
+
+                let price_delta = base_price.abs_diff(current_price) / base_price;
+
+                let scaled_price_delta = price_delta * scalar;
+
+                let scaled_swap_amount = if current_price < base_price {
+                    swap_amount
+                        .amount
+                        .mul_floor(Decimal::one().saturating_add(scaled_price_delta))
+                } else {
+                    swap_amount
+                        .amount
+                        .mul_floor(Decimal::one().saturating_sub(scaled_price_delta))
+                };
+
+                let new_swap_amount = Coin::new(
+                    max(
+                        scaled_swap_amount,
+                        minimum_swap_amount
+                            .clone()
+                            .unwrap_or(Coin::new(0u128, self.swap_amount.denom.clone()))
+                            .amount,
+                    ),
+                    self.swap_amount.denom,
+                );
+
+                if new_swap_amount.amount.is_zero() {
+                    return Err(StdError::generic_err(
+                        "Swap amount after adjustment is zero".to_string(),
+                    ));
+                }
+
+                let new_minimum_receive_amount =
+                    self.minimum_receive_amount
+                        .amount
+                        .mul_ceil(Decimal::from_ratio(
+                            new_swap_amount.amount,
+                            self.swap_amount.amount,
+                        ));
+
+                (new_swap_amount, new_minimum_receive_amount)
+            }
+        };
+
+        Ok(SwapQuote {
+            swap_amount: new_swap_amount,
+            minimum_receive_amount: Coin::new(
+                new_minimum_receive_amount,
+                self.minimum_receive_amount.denom,
+            ),
+            maximum_slippage_bps: self.maximum_slippage_bps,
+            adjustment: self.adjustment,
+            route: self.route,
+            state: Adjusted,
+        })
     }
 }
 
@@ -135,12 +206,8 @@ impl SwapQuote<Adjusted> {
 
 impl SwapQuote<Executable> {
     pub fn execute(&self, deps: Deps, env: &Env) -> StdResult<CosmosMsg> {
-        self.route.execute(
-            deps,
-            env,
-            self.swap_amount.clone(),
-            self.minimum_receive_amount.clone(),
-        )
+        self.route
+            .execute(deps, env, &self.swap_amount, &self.minimum_receive_amount)
     }
 }
 
@@ -167,6 +234,31 @@ impl Swap {
 
         if self.routes.is_empty() {
             return Err(StdError::generic_err("No swap routes provided"));
+        }
+
+        if let SwapAmountAdjustment::LinearScalar {
+            base_receive_amount,
+            minimum_swap_amount,
+            ..
+        } = &self.adjustment
+        {
+            if base_receive_amount.amount.is_zero() {
+                return Err(StdError::generic_err("Base receive amount cannot be zero"));
+            }
+
+            if base_receive_amount.denom != self.minimum_receive_amount.denom {
+                return Err(StdError::generic_err(
+                    "Base receive amount denom must match minimum receive amount denom",
+                ));
+            }
+
+            if let Some(minimum_swap_amount) = minimum_swap_amount {
+                if minimum_swap_amount.denom != self.swap_amount.denom {
+                    return Err(StdError::generic_err(
+                        "Minimum swap amount denom must match swap amount denom",
+                    ));
+                }
+            }
         }
 
         for route in &self.routes {
@@ -274,5 +366,245 @@ impl Operation<Swap> for Swap {
             Ok((messages, swap)) => (messages, swap),
             Err(_) => (vec![], self),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use calc_rs_test::mocks::mock_dependencies_with_custom_grpc_querier;
+    use cosmwasm_std::{
+        testing::{mock_dependencies, mock_env},
+        to_json_binary, Addr, Binary, Coin, ContractResult, Decimal, SystemResult, Uint128,
+    };
+    use prost::Message;
+    use rujira_rs::{fin::SimulationResponse, proto::types::QueryQuoteSwapResponse};
+
+    use crate::actions::swaps::{
+        fin::FinRoute,
+        swap::{New, SwapAmountAdjustment, SwapQuote, SwapRoute},
+        thor::ThorchainRoute,
+    };
+
+    #[test]
+    fn test_linear_scalar_swap_adjustment_with_fin_route() {
+        let mut deps = mock_dependencies();
+        let env = mock_env();
+
+        deps.querier
+            .bank
+            .update_balance(&env.contract.address, vec![Coin::new(1000u128, "rune")]);
+
+        let quote = SwapQuote {
+            swap_amount: Coin::new(1000u128, "rune"),
+            minimum_receive_amount: Coin::new(1u128, "x/ruji"),
+            maximum_slippage_bps: 300,
+            adjustment: SwapAmountAdjustment::LinearScalar {
+                base_receive_amount: Coin::new(500u128, "x/ruji"),
+                minimum_swap_amount: None,
+                scalar: Decimal::one(),
+            },
+            route: SwapRoute::Fin(FinRoute {
+                pair_address: Addr::unchecked("pair_address"),
+            }),
+            state: New,
+        };
+
+        // Price at $2.00
+
+        deps.querier.update_wasm(|_| {
+            SystemResult::Ok(ContractResult::Ok(
+                to_json_binary(&SimulationResponse {
+                    returned: Uint128::new(500),
+                    fee: Uint128::zero(),
+                })
+                .unwrap(),
+            ))
+        });
+
+        let adjusted_quote = quote.clone().adjust(deps.as_ref(), &env).unwrap();
+
+        assert_eq!(adjusted_quote.swap_amount, quote.swap_amount);
+
+        // Price at $3.00
+
+        deps.querier.update_wasm(|_| {
+            SystemResult::Ok(ContractResult::Ok(
+                to_json_binary(&SimulationResponse {
+                    returned: Uint128::new(334),
+                    fee: Uint128::zero(),
+                })
+                .unwrap(),
+            ))
+        });
+
+        let adjusted_quote = quote.clone().adjust(deps.as_ref(), &env).unwrap();
+
+        assert_eq!(
+            adjusted_quote.swap_amount.amount,
+            quote.swap_amount.amount.mul_floor(Decimal::permille(502))
+        );
+
+        // Price at $1.00
+
+        deps.querier.update_wasm(|_| {
+            SystemResult::Ok(ContractResult::Ok(
+                to_json_binary(&SimulationResponse {
+                    returned: Uint128::new(1000),
+                    fee: Uint128::zero(),
+                })
+                .unwrap(),
+            ))
+        });
+
+        let adjusted_quote = quote.clone().adjust(deps.as_ref(), &env).unwrap();
+
+        assert_eq!(
+            adjusted_quote.swap_amount.amount,
+            quote.swap_amount.amount.mul_floor(Decimal::percent(150))
+        );
+    }
+
+    #[test]
+    fn test_linear_scalar_swap_adjustment_with_thorchain_route() {
+        let mut deps = mock_dependencies_with_custom_grpc_querier();
+        let env = mock_env();
+
+        deps.querier
+            .default
+            .bank
+            .update_balance(&env.contract.address, vec![Coin::new(1000u128, "rune")]);
+
+        let quote = SwapQuote {
+            swap_amount: Coin::new(1000u128, "rune"),
+            minimum_receive_amount: Coin::new(1u128, "x/ruji"),
+            maximum_slippage_bps: 300,
+            adjustment: SwapAmountAdjustment::LinearScalar {
+                base_receive_amount: Coin::new(500u128, "x/ruji"),
+                minimum_swap_amount: None,
+                scalar: Decimal::one(),
+            },
+            route: SwapRoute::Thorchain(ThorchainRoute {
+                streaming_interval: None,
+                max_streaming_quantity: None,
+                affiliate_code: None,
+                affiliate_bps: None,
+                latest_swap: None,
+            }),
+            state: New,
+        };
+
+        // Price at $2.00
+
+        deps.querier.with_grpc_handler(|_| {
+            let quote = QueryQuoteSwapResponse {
+                fees: None,
+                expiry: i64::MAX,
+                warning: String::new(),
+                notes: String::new(),
+                dust_threshold: "0".to_string(),
+                recommended_min_amount_in: "1".to_string(),
+                gas_rate_units: "rune".to_string(),
+                memo: "swap".to_string(),
+                expected_amount_out: "500".to_string(),
+                max_streaming_quantity: 5,
+                streaming_swap_blocks: 5,
+                inbound_address: "destination".to_string(),
+                inbound_confirmation_blocks: 10,
+                inbound_confirmation_seconds: 10,
+                outbound_delay_blocks: 10,
+                outbound_delay_seconds: 10,
+                router: String::new(),
+                recommended_gas_rate: String::new(),
+                streaming_swap_seconds: 10,
+                total_swap_seconds: 10,
+            };
+
+            let mut buf = Vec::new();
+            quote.encode(&mut buf).unwrap();
+
+            SystemResult::Ok(ContractResult::Ok(Binary::from(buf)))
+        });
+
+        let adjusted_quote = quote.clone().adjust(deps.as_ref(), &env).unwrap();
+
+        assert_eq!(adjusted_quote.swap_amount, quote.swap_amount);
+
+        // Price at $3.00
+
+        deps.querier.with_grpc_handler(|_| {
+            let quote = QueryQuoteSwapResponse {
+                fees: None,
+                expiry: i64::MAX,
+                warning: String::new(),
+                notes: String::new(),
+                dust_threshold: "0".to_string(),
+                recommended_min_amount_in: "1".to_string(),
+                gas_rate_units: "rune".to_string(),
+                memo: "swap".to_string(),
+                expected_amount_out: "334".to_string(),
+                max_streaming_quantity: 5,
+                streaming_swap_blocks: 5,
+                inbound_address: "destination".to_string(),
+                inbound_confirmation_blocks: 10,
+                inbound_confirmation_seconds: 10,
+                outbound_delay_blocks: 10,
+                outbound_delay_seconds: 10,
+                router: String::new(),
+                recommended_gas_rate: String::new(),
+                streaming_swap_seconds: 10,
+                total_swap_seconds: 10,
+            };
+
+            let mut buf = Vec::new();
+            quote.encode(&mut buf).unwrap();
+
+            SystemResult::Ok(ContractResult::Ok(Binary::from(buf)))
+        });
+
+        let adjusted_quote = quote.clone().adjust(deps.as_ref(), &env).unwrap();
+
+        assert_eq!(
+            adjusted_quote.swap_amount.amount,
+            quote.swap_amount.amount.mul_floor(Decimal::permille(502))
+        );
+
+        // // Price at $1.00
+
+        deps.querier.with_grpc_handler(|_| {
+            let quote = QueryQuoteSwapResponse {
+                fees: None,
+                expiry: i64::MAX,
+                warning: String::new(),
+                notes: String::new(),
+                dust_threshold: "0".to_string(),
+                recommended_min_amount_in: "1".to_string(),
+                gas_rate_units: "rune".to_string(),
+                memo: "swap".to_string(),
+                expected_amount_out: "1000".to_string(),
+                max_streaming_quantity: 5,
+                streaming_swap_blocks: 5,
+                inbound_address: "destination".to_string(),
+                inbound_confirmation_blocks: 10,
+                inbound_confirmation_seconds: 10,
+                outbound_delay_blocks: 10,
+                outbound_delay_seconds: 10,
+                router: String::new(),
+                recommended_gas_rate: String::new(),
+                streaming_swap_seconds: 10,
+                total_swap_seconds: 10,
+            };
+
+            let mut buf = Vec::new();
+            quote.encode(&mut buf).unwrap();
+
+            SystemResult::Ok(ContractResult::Ok(Binary::from(buf)))
+        });
+
+        let adjusted_quote = quote.clone().adjust(deps.as_ref(), &env).unwrap();
+
+        assert_eq!(
+            adjusted_quote.swap_amount.amount,
+            quote.swap_amount.amount.mul_floor(Decimal::percent(150))
+        );
     }
 }

--- a/packages/calc-rs/src/actions/swaps/thor.rs
+++ b/packages/calc-rs/src/actions/swaps/thor.rs
@@ -1,16 +1,11 @@
-use std::{
-    cmp::{max, min},
-    vec,
-};
+use std::vec;
 
 use crate::{
-    actions::swaps::swap::{
-        Adjusted, Executable, New, Quotable, SwapAmountAdjustment, SwapQuote, SwapRoute,
-    },
+    actions::swaps::swap::{Adjusted, Executable, New, SwapQuote, SwapRoute},
     thorchain::{is_secured_asset, MsgDeposit, SwapQuote as ThorchainSwapQuote, SwapQuoteRequest},
 };
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Coin, CosmosMsg, Decimal, Deps, Env, StdError, StdResult, Uint128};
+use cosmwasm_std::{Coin, CosmosMsg, Deps, Env, StdError, StdResult, Uint128};
 
 #[cw_serde]
 pub struct StreamingSwap {
@@ -30,8 +25,8 @@ pub struct ThorchainRoute {
     pub latest_swap: Option<StreamingSwap>,
 }
 
-impl Quotable for ThorchainRoute {
-    fn validate(&self, _deps: Deps, route: &SwapQuote<New>) -> StdResult<()> {
+impl ThorchainRoute {
+    pub fn validate(&self, _deps: Deps, route: &SwapQuote<New>) -> StdResult<()> {
         if !is_secured_asset(route.swap_amount.denom.as_str()) {
             return Err(StdError::generic_err(
                 "Swap denom must be RUNE or a secured asset",
@@ -74,200 +69,92 @@ impl Quotable for ThorchainRoute {
         Ok(())
     }
 
-    fn adjust(
+    pub fn get_expected_amount_out(
         &self,
         deps: Deps,
-        env: &Env,
-        route: SwapQuote<New>,
-    ) -> StdResult<SwapQuote<Adjusted>> {
-        let (new_swap_amount, new_minimum_receive_amount, max_streaming_quantity) =
-            match route.adjustment.clone() {
-                SwapAmountAdjustment::Fixed => {
-                    let swap_balance = deps.querier.query_balance(
-                        env.contract.address.clone(),
-                        route.swap_amount.denom.clone(),
-                    )?;
-
-                    let new_swap_amount = Coin::new(
-                        min(swap_balance.amount, route.swap_amount.amount),
-                        route.swap_amount.denom.clone(),
-                    );
-
-                    let new_minimum_receive_amount = Coin::new(
-                        route
-                            .minimum_receive_amount
-                            .amount
-                            .mul_floor(Decimal::from_ratio(
-                                new_swap_amount.amount,
-                                route.swap_amount.amount,
-                            )),
-                        route.minimum_receive_amount.denom.clone(),
-                    );
-
-                    let quote = get_swap_quote(deps, &route)?;
-
-                    (
-                        new_swap_amount,
-                        new_minimum_receive_amount,
-                        min(
-                            quote.max_streaming_quantity,
-                            self.max_streaming_quantity
-                                .unwrap_or(quote.max_streaming_quantity),
-                        ),
-                    )
-                }
-                SwapAmountAdjustment::LinearScalar {
-                    base_receive_amount,
-                    minimum_swap_amount,
-                    scalar,
-                } => {
-                    let quote = get_swap_quote(deps, &route)?;
-
-                    let base_price =
-                        Decimal::from_ratio(base_receive_amount.amount, route.swap_amount.amount);
-
-                    let current_price =
-                        Decimal::from_ratio(route.swap_amount.amount, quote.expected_amount_out);
-
-                    let price_delta = base_price.abs_diff(current_price) / base_price;
-                    let scaled_price_delta = price_delta * scalar;
-
-                    let scaled_swap_amount = if current_price < base_price {
-                        route
-                            .swap_amount
-                            .amount
-                            .mul_floor(Decimal::one().saturating_add(scaled_price_delta))
-                    } else {
-                        route
-                            .swap_amount
-                            .amount
-                            .mul_floor(Decimal::one().saturating_sub(scaled_price_delta))
-                    };
-
-                    let new_swap_amount = Coin::new(
-                        max(
-                            scaled_swap_amount,
-                            minimum_swap_amount
-                                .clone()
-                                .unwrap_or(Coin::new(0u128, route.swap_amount.denom.clone()))
-                                .amount,
-                        ),
-                        route.swap_amount.denom.clone(),
-                    );
-
-                    let new_minimum_receive_amount = Coin::new(
-                        route
-                            .minimum_receive_amount
-                            .amount
-                            .mul_ceil(Decimal::from_ratio(
-                                new_swap_amount.amount,
-                                route.swap_amount.amount,
-                            )),
-                        route.minimum_receive_amount.denom.clone(),
-                    );
-
-                    (
-                        new_swap_amount,
-                        new_minimum_receive_amount,
-                        min(
-                            quote.max_streaming_quantity,
-                            self.max_streaming_quantity
-                                .unwrap_or(quote.max_streaming_quantity),
-                        ),
-                    )
-                }
-            };
-
-        Ok(SwapQuote {
-            swap_amount: new_swap_amount,
-            minimum_receive_amount: new_minimum_receive_amount,
-            maximum_slippage_bps: route.maximum_slippage_bps,
-            adjustment: route.adjustment,
-            route: SwapRoute::Thorchain(ThorchainRoute {
-                max_streaming_quantity: Some(max_streaming_quantity),
-                ..self.clone()
-            }),
-            state: Adjusted,
-        })
+        quote: &SwapQuote<New>,
+    ) -> StdResult<Uint128> {
+        let quote = get_thorchain_swap_quote(deps, quote)?;
+        Ok(quote.expected_amount_out)
     }
 
-    fn validate_adjusted(
-        &self,
+    pub fn validate_adjusted(
+        self,
         deps: Deps,
         env: &Env,
-        route: SwapQuote<Adjusted>,
+        quote: SwapQuote<Adjusted>,
     ) -> StdResult<SwapQuote<Executable>> {
-        if route.swap_amount.amount.is_zero() {
+        if quote.swap_amount.amount.is_zero() {
             return Err(StdError::generic_err("Swap amount cannot be zero"));
         }
 
-        let adjusted_quote = get_swap_quote(deps, &route)?;
+        let adjusted_quote = get_thorchain_swap_quote(deps, &quote)?;
 
         if let Some(fees) = adjusted_quote.fees {
-            if fees.slippage_bps > route.maximum_slippage_bps {
+            if fees.slippage_bps > quote.maximum_slippage_bps {
                 return Err(StdError::generic_err(format!(
                     "Slippage BPS ({}) exceeds maximum allowed ({})",
-                    fees.slippage_bps, route.maximum_slippage_bps
+                    fees.slippage_bps, quote.maximum_slippage_bps
                 )));
             }
         }
 
-        if adjusted_quote.expected_amount_out < route.minimum_receive_amount.amount {
+        if adjusted_quote.expected_amount_out < quote.minimum_receive_amount.amount {
             return Err(StdError::generic_err(format!(
                 "Expected amount out ({}) is less than minimum receive amount ({})",
-                adjusted_quote.expected_amount_out, route.minimum_receive_amount.amount
+                adjusted_quote.expected_amount_out, quote.minimum_receive_amount.amount
             )));
         }
 
-        if adjusted_quote.recommended_min_amount_in > route.swap_amount.amount {
+        if adjusted_quote.recommended_min_amount_in > quote.swap_amount.amount {
             return Err(StdError::generic_err(format!(
                 "Recommended min amount in ({}) is greater than swap amount ({})",
-                adjusted_quote.recommended_min_amount_in, route.swap_amount.amount
+                adjusted_quote.recommended_min_amount_in, quote.swap_amount.amount
             )));
         }
 
         Ok(SwapQuote {
-            swap_amount: route.swap_amount.clone(),
-            minimum_receive_amount: route.minimum_receive_amount.clone(),
-            maximum_slippage_bps: route.maximum_slippage_bps,
-            adjustment: route.adjustment,
+            swap_amount: quote.swap_amount.clone(),
+            minimum_receive_amount: quote.minimum_receive_amount.clone(),
+            maximum_slippage_bps: quote.maximum_slippage_bps,
+            adjustment: quote.adjustment,
             route: SwapRoute::Thorchain(ThorchainRoute {
                 latest_swap: Some(StreamingSwap {
-                    swap_amount: route.swap_amount,
+                    swap_amount: quote.swap_amount,
                     expected_receive_amount: Coin::new(
                         adjusted_quote.expected_amount_out,
-                        route.minimum_receive_amount.denom.clone(),
+                        quote.minimum_receive_amount.denom.clone(),
                     ),
                     starting_block: env.block.height + 1,
                     streaming_swap_blocks: adjusted_quote.streaming_swap_blocks,
                     memo: adjusted_quote.memo,
                 }),
-                ..self.clone()
+                ..self
             }),
             state: Executable {
                 expected_amount_out: Coin::new(
                     adjusted_quote.expected_amount_out,
-                    route.minimum_receive_amount.denom,
+                    quote.minimum_receive_amount.denom,
                 ),
             },
         })
     }
 
-    fn execute(
+    pub fn execute(
         &self,
         deps: Deps,
         env: &Env,
-        swap_amount: Coin,
-        _minimum_receive_amount: Coin,
+        swap_amount: &Coin,
+        _minimum_receive_amount: &Coin,
     ) -> StdResult<CosmosMsg> {
-        let current_swap = if let Some(current_swap) = self.latest_swap.clone() {
+        let current_swap = if let Some(current_swap) = &self.latest_swap {
             current_swap
         } else {
             return Err(StdError::generic_err("No current swap found to execute"));
         };
 
         let swap_msg = MsgDeposit {
-            memo: current_swap.memo,
+            memo: current_swap.memo.clone(),
             coins: vec![swap_amount.clone()],
             signer: deps.api.addr_canonicalize(env.contract.address.as_str())?,
         }
@@ -315,7 +202,10 @@ impl<S> TryFrom<&SwapQuote<S>> for SwapQuoteRequest {
     }
 }
 
-pub fn get_swap_quote<S>(deps: Deps, quote: &SwapQuote<S>) -> StdResult<ThorchainSwapQuote> {
+pub fn get_thorchain_swap_quote<S>(
+    deps: Deps,
+    quote: &SwapQuote<S>,
+) -> StdResult<ThorchainSwapQuote> {
     ThorchainSwapQuote::get(deps.querier, &SwapQuoteRequest::try_from(quote)?).map_err(|e| {
         StdError::generic_err(format!(
             "Failed to get L1 swap quote with {:?}: {e}",

--- a/tests/src/integration.rs
+++ b/tests/src/integration.rs
@@ -929,7 +929,7 @@ mod integration_tests {
         let swap_action = Swap {
             adjustment: SwapAmountAdjustment::LinearScalar {
                 base_receive_amount: Coin::new(
-                    10u128,
+                    100000000000000u128,
                     default_swap_action.minimum_receive_amount.denom.clone(),
                 ),
                 minimum_swap_amount: Some(minimum_swap_amount.clone()),
@@ -1257,7 +1257,7 @@ mod integration_tests {
         let swap_action = Swap {
             adjustment: SwapAmountAdjustment::LinearScalar {
                 base_receive_amount: Coin::new(
-                    10u128,
+                    100000000000000u128,
                     default_swap_action.minimum_receive_amount.denom.clone(),
                 ),
                 minimum_swap_amount: Some(minimum_swap_amount.clone()),


### PR DESCRIPTION
Address findings 005 and 006 in the Halborn audit.

Changes include:

* Refactor out a `get_expected_amount_out` method for each route type and consolidate the remaining `adjust` method functionality into a single `SwapQuote` method implementation
* Fix inverse price comparison issue `FIND-005`
* Include balance check for thorchain swaps `FIND-006`
* Add new unit tests and fix existing integration tests