### PR TITLE
Remove limit order schedule cadence and associated execution logic

### DIFF
--- a/contracts/scheduler/src/contract.rs
+++ b/contracts/scheduler/src/contract.rs
@@ -9,10 +9,9 @@ use cosmwasm_schema::cw_serde;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_json_binary, BankMsg, Binary, Coin, Coins, Deps, DepsMut, Env, MessageInfo, Reply, Response,
+    to_json_binary, BankMsg, Binary, Coins, Deps, DepsMut, Env, MessageInfo, Reply, Response,
     StdResult, SubMsg, SubMsgResult,
 };
-use rujira_rs::fin::{ConfigResponse, ExecuteMsg, OrderResponse, Price, QueryMsg};
 
 use crate::state::TRIGGERS;
 
@@ -52,9 +51,7 @@ pub fn execute(
             }
 
             match create_command.condition {
-                Condition::BlocksCompleted(_)
-                | Condition::TimestampElapsed(_)
-                | Condition::FinLimitOrderFilled { .. } => {}
+                Condition::BlocksCompleted(_) | Condition::TimestampElapsed(_) => {}
                 _ => {
                     return Err(ContractError::generic_err(format!(
                         "Unsupported condition type for trigger: {:#?}",
@@ -83,40 +80,6 @@ pub fn execute(
                 }
             }
 
-            let mut execution_rebate = Coins::try_from(info.funds)?;
-
-            if let Condition::FinLimitOrderFilled {
-                pair_address,
-                side,
-                price,
-                ..
-            } = &create_command.condition
-            {
-                let pair = deps.querier.query_wasm_smart::<ConfigResponse>(
-                    pair_address.clone(),
-                    &QueryMsg::Config {},
-                )?;
-
-                let bid_denom = pair.denoms.bid(side);
-                let bid_amount = Coin::new(execution_rebate.amount_of(bid_denom), bid_denom);
-
-                if bid_amount.amount.is_zero() {
-                    return Err(ContractError::generic_err("No funds sent for limit order"));
-                }
-
-                execution_rebate.sub(bid_amount.clone())?;
-
-                let set_order_msg = SubMsg::reply_never(Contract(pair_address.clone()).call(
-                    to_json_binary(&ExecuteMsg::Order((
-                        vec![(side.clone(), Price::Fixed(*price), Some(bid_amount.amount))],
-                        None,
-                    )))?,
-                    vec![bid_amount],
-                ));
-
-                sub_messages.push(set_order_msg);
-            }
-
             TRIGGERS.save(
                 deps.storage,
                 &Trigger {
@@ -126,7 +89,7 @@ pub fn execute(
                     msg: create_command.msg,
                     contract_address: create_command.contract_address,
                     executors: create_command.executors,
-                    execution_rebate: execution_rebate.to_vec(),
+                    execution_rebate: Coins::try_from(info.funds)?.to_vec(),
                     jitter: create_command.jitter,
                 },
             )?;
@@ -134,7 +97,7 @@ pub fn execute(
             Ok(Response::new().add_submessages(sub_messages))
         }
         SchedulerExecuteMsg::Execute(ids) => {
-            let mut sub_messages = Vec::with_capacity(ids.len() * 3);
+            let mut sub_messages = Vec::with_capacity(ids.len() * 2);
 
             for id in ids {
                 let trigger = match TRIGGERS.load(deps.storage, id) {
@@ -146,62 +109,19 @@ pub fn execute(
                     continue;
                 }
 
-                if let Ok(trigger_is_satisfied) =
-                    trigger.condition.is_satisfied(deps.as_ref(), &env)
-                {
-                    if !trigger_is_satisfied {
-                        continue;
-                    }
-
-                    if let Condition::FinLimitOrderFilled {
-                        pair_address,
-                        side,
-                        price,
-                        ..
-                    } = trigger.condition
-                    {
-                        let order = deps.querier.query_wasm_smart::<OrderResponse>(
-                            &pair_address,
-                            &QueryMsg::Order((
-                                env.contract.address.to_string(),
-                                side.clone(),
-                                Price::Fixed(price),
-                            )),
-                        )?;
-
-                        let withdraw_order_msg =
-                            SubMsg::reply_never(Contract(pair_address.clone()).call(
-                                to_json_binary(&ExecuteMsg::Order((
-                                    vec![(side.clone(), Price::Fixed(price), None)],
-                                    None,
-                                )))?,
-                                vec![],
-                            ));
-
-                        sub_messages.push(withdraw_order_msg);
-
-                        let pair = deps.querier.query_wasm_smart::<ConfigResponse>(
-                            pair_address,
-                            &QueryMsg::Config {},
-                        )?;
-
-                        let rebate_msg = SubMsg::reply_never(BankMsg::Send {
-                            to_address: info.sender.to_string(),
-                            amount: vec![Coin::new(order.filled, pair.denoms.ask(&side))],
-                        });
-
-                        sub_messages.push(rebate_msg);
-                    }
+                match trigger.condition.is_satisfied(deps.as_ref(), &env) {
+                    Ok(true) => {}
+                    _ => continue,
                 }
 
                 TRIGGERS.delete(deps.storage, trigger.id.into())?;
 
-                let execute_msg = SubMsg::reply_on_error(
+                let execute_trigger_msg = SubMsg::reply_on_error(
                     Contract(trigger.contract_address).call(trigger.msg, vec![]),
                     0,
                 );
 
-                sub_messages.push(execute_msg);
+                sub_messages.push(execute_trigger_msg);
 
                 if !trigger.execution_rebate.is_empty() {
                     let rebate_msg = SubMsg::reply_never(BankMsg::Send {
@@ -250,9 +170,8 @@ mod create_trigger_tests {
     };
     use cosmwasm_std::{
         testing::{message_info, mock_dependencies, mock_env},
-        Addr, Coin, ContractResult as ContractQueryResult, Decimal, SystemResult,
+        Addr, Coin,
     };
-    use rujira_rs::fin::{Denoms, Price, Side, Tick};
 
     #[test]
     fn creates_block_trigger_correctly() {
@@ -400,244 +319,6 @@ mod create_trigger_tests {
     }
 
     #[test]
-    fn fails_to_create_limit_order_trigger_if_no_bid_amount_sent() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let owner = deps.api.addr_make("creator");
-
-        let pair_address = Addr::unchecked("pair-0");
-
-        let condition = Condition::FinLimitOrderFilled {
-            owner: Some(Addr::unchecked("owner")),
-            pair_address,
-            side: Side::Base,
-            price: Decimal::percent(100),
-        };
-
-        deps.querier.update_wasm(|_| {
-            SystemResult::Ok(ContractQueryResult::Ok(
-                to_json_binary(&ConfigResponse {
-                    denoms: Denoms::new("btc-btc", "rune"),
-                    oracles: None,
-                    market_maker: None,
-                    tick: Tick::new(1),
-                    fee_taker: Decimal::percent(10),
-                    fee_maker: Decimal::percent(5),
-                    fee_address: Addr::unchecked("fee_address").to_string(),
-                })
-                .unwrap(),
-            ))
-        });
-
-        assert!(execute(
-            deps.as_mut(),
-            env.clone(),
-            message_info(&owner, &[]),
-            SchedulerExecuteMsg::Create(Box::new(CreateTriggerMsg {
-                condition: condition.clone(),
-                msg: Binary::default(),
-                contract_address: owner.clone(),
-                executors: vec![],
-                jitter: None
-            })),
-        )
-        .unwrap_err()
-        .to_string()
-        .contains("No funds sent for limit order"));
-
-        assert!(execute(
-            deps.as_mut(),
-            env.clone(),
-            message_info(&owner, &[Coin::new(1213_u128, "random-denom")]),
-            SchedulerExecuteMsg::Create(Box::new(CreateTriggerMsg {
-                condition: condition.clone(),
-                msg: Binary::default(),
-                contract_address: owner.clone(),
-                executors: vec![],
-                jitter: None
-            })),
-        )
-        .unwrap_err()
-        .to_string()
-        .contains("No funds sent for limit order"));
-    }
-
-    #[test]
-    fn fails_to_create_limit_order_trigger_if_pair_does_not_exist() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let owner = deps.api.addr_make("creator");
-        let info = message_info(&owner, &[Coin::new(1234_u128, "rune")]);
-
-        let pair_address = Addr::unchecked("pair-0");
-
-        let condition = Condition::FinLimitOrderFilled {
-            owner: Some(Addr::unchecked("owner")),
-            pair_address: pair_address.clone(),
-            side: Side::Base,
-            price: Decimal::percent(100),
-        };
-
-        assert!(execute(
-            deps.as_mut(),
-            env.clone(),
-            info,
-            SchedulerExecuteMsg::Create(Box::new(CreateTriggerMsg {
-                condition: condition.clone(),
-                msg: Binary::default(),
-                contract_address: owner.clone(),
-                executors: vec![],
-                jitter: None
-            })),
-        )
-        .unwrap_err()
-        .to_string()
-        .contains(format!("Querier system error: No such contract: {pair_address}").as_str()));
-    }
-
-    #[test]
-    fn sets_limit_order_with_provided_bid_denom_funds() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let owner = deps.api.addr_make("creator");
-        let bid_amount = Coin::new(1234_u128, "btc-btc");
-        let info = message_info(&owner, &[bid_amount.clone()]);
-
-        let pair_address = Addr::unchecked("pair-0");
-        let side = Side::Base;
-        let price = Decimal::percent(100);
-
-        let condition = Condition::FinLimitOrderFilled {
-            owner: Some(Addr::unchecked("owner")),
-            pair_address: pair_address.clone(),
-            side: side.clone(),
-            price,
-        };
-
-        deps.querier.update_wasm(|_| {
-            SystemResult::Ok(ContractQueryResult::Ok(
-                to_json_binary(&ConfigResponse {
-                    denoms: Denoms::new("btc-btc", "rune"),
-                    oracles: None,
-                    market_maker: None,
-                    tick: Tick::new(1),
-                    fee_taker: Decimal::percent(10),
-                    fee_maker: Decimal::percent(5),
-                    fee_address: Addr::unchecked("fee_address").to_string(),
-                })
-                .unwrap(),
-            ))
-        });
-
-        let response = execute(
-            deps.as_mut(),
-            env.clone(),
-            info,
-            SchedulerExecuteMsg::Create(Box::new(CreateTriggerMsg {
-                condition: condition.clone(),
-                msg: Binary::default(),
-                contract_address: owner.clone(),
-                executors: vec![],
-                jitter: None,
-            })),
-        )
-        .unwrap();
-
-        assert_eq!(
-            response.messages,
-            vec![SubMsg::reply_never(
-                Contract(pair_address.clone()).call(
-                    to_json_binary(&ExecuteMsg::Order((
-                        vec![(side, Price::Fixed(price), Some(bid_amount.amount),)],
-                        None,
-                    )))
-                    .unwrap(),
-                    vec![bid_amount],
-                ),
-            )]
-        )
-    }
-
-    #[test]
-    fn saves_remaining_funds_as_limit_order_trigger_execution_rebate() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let owner = deps.api.addr_make("creator");
-        let info = message_info(
-            &owner,
-            &[
-                Coin::new(1234_u128, "rune"),
-                Coin::new(1234_u128, "eth-eth"),
-            ],
-        );
-
-        let pair_address = Addr::unchecked("pair-0");
-
-        let condition = Condition::FinLimitOrderFilled {
-            owner: Some(Addr::unchecked("owner")),
-            pair_address: pair_address.clone(),
-            side: Side::Quote,
-            price: Decimal::percent(100),
-        };
-
-        deps.querier.update_wasm(|_| {
-            SystemResult::Ok(ContractQueryResult::Ok(
-                to_json_binary(&ConfigResponse {
-                    denoms: Denoms::new("btc-btc", "rune"),
-                    oracles: None,
-                    market_maker: None,
-                    tick: Tick::new(1),
-                    fee_taker: Decimal::percent(10),
-                    fee_maker: Decimal::percent(5),
-                    fee_address: Addr::unchecked("fee_address").to_string(),
-                })
-                .unwrap(),
-            ))
-        });
-
-        let create_trigger_msg = CreateTriggerMsg {
-            condition: condition.clone(),
-            msg: Binary::default(),
-            contract_address: owner.clone(),
-            executors: vec![],
-            jitter: None,
-        };
-
-        execute(
-            deps.as_mut(),
-            env.clone(),
-            info,
-            SchedulerExecuteMsg::Create(Box::new(create_trigger_msg.clone())),
-        )
-        .unwrap();
-
-        let triggers = TRIGGERS
-            .filtered(
-                deps.as_ref().storage,
-                ConditionFilter::LimitOrder {
-                    pair_address: pair_address.clone(),
-                    price_range: None,
-                },
-                None,
-            )
-            .unwrap();
-
-        assert_eq!(
-            triggers,
-            vec![Trigger {
-                id: create_trigger_msg.id(&owner).unwrap(),
-                owner: owner.clone(),
-                contract_address: owner,
-                msg: Binary::default(),
-                executors: vec![],
-                jitter: None,
-                condition: condition.clone(),
-                execution_rebate: vec![Coin::new(1234_u128, "eth-eth")],
-            }]
-        );
-    }
-
-    #[test]
     fn cannot_overwrite_trigger_with_different_owner() {
         let mut deps = mock_dependencies();
         let env = mock_env();
@@ -692,12 +373,11 @@ mod execute_trigger_tests {
     use calc_rs::manager::ManagerExecuteMsg;
     use calc_rs::scheduler::{ConditionFilter, CreateTriggerMsg};
     use cosmwasm_std::testing::message_info;
-    use cosmwasm_std::{from_json, Addr, Decimal, Uint128, Uint64, WasmMsg, WasmQuery};
     use cosmwasm_std::{
         testing::{mock_dependencies, mock_env},
-        Coin, ContractResult as CosmosContractResult, SubMsg, SystemResult,
+        Coin, SubMsg,
     };
-    use rujira_rs::fin::{ConfigResponse, Denoms, OrderResponse, Price, QueryMsg, Side, Tick};
+    use cosmwasm_std::{Uint64, WasmMsg};
 
     #[test]
     fn fails_silently_if_trigger_does_not_exist() {
@@ -754,119 +434,6 @@ mod execute_trigger_tests {
         .unwrap();
 
         assert!(response.messages.is_empty());
-    }
-
-    #[test]
-    fn withdraws_limit_order_if_trigger_can_execute() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let owner = deps.api.addr_make("creator");
-        let executor = deps.api.addr_make("executor");
-        let manager = deps.api.addr_make("manager");
-
-        let side = Side::Base;
-        let price = Decimal::percent(100);
-
-        let condition = Condition::FinLimitOrderFilled {
-            owner: Some(Addr::unchecked("owner")),
-            pair_address: Addr::unchecked("pair-0"),
-            side: side.clone(),
-            price,
-        };
-
-        deps.querier.update_wasm(move |query| {
-            SystemResult::Ok(CosmosContractResult::Ok(match query {
-                WasmQuery::Smart { msg, .. } => match from_json(msg).unwrap() {
-                    QueryMsg::Config {} => to_json_binary(&ConfigResponse {
-                        denoms: Denoms::new("btc-btc", "rune"),
-                        oracles: None,
-                        market_maker: None,
-                        tick: Tick::new(1),
-                        fee_taker: Decimal::percent(10),
-                        fee_maker: Decimal::percent(5),
-                        fee_address: Addr::unchecked("fee_address").to_string(),
-                    })
-                    .unwrap(),
-                    QueryMsg::Order(_) => to_json_binary(&OrderResponse {
-                        filled: Uint128::new(21312),
-                        owner: Addr::unchecked("contract").to_string(),
-                        rate: Decimal::percent(10),
-                        updated_at: env.block.time,
-                        offer: Uint128::new(12321),
-                        remaining: Uint128::zero(),
-                        side: Side::Base,
-                        price: Price::Fixed(Decimal::percent(100)),
-                    })
-                    .unwrap(),
-                    _ => panic!("Unexpected query type"),
-                },
-                _ => panic!("Unexpected query type"),
-            }))
-        });
-
-        let remaining_rebate = Coin::new(12312u128, "other");
-
-        TRIGGERS
-            .save(
-                deps.as_mut().storage,
-                &Trigger {
-                    id: Uint64::new(156434254),
-                    owner: owner.clone(),
-                    contract_address: manager.clone(),
-                    msg: to_json_binary(&ManagerExecuteMsg::Execute {
-                        contract_address: owner.clone(),
-                    })
-                    .unwrap(),
-                    condition: condition.clone(),
-                    execution_rebate: vec![remaining_rebate.clone()],
-                    executors: vec![],
-                    jitter: None,
-                },
-            )
-            .unwrap();
-
-        let response = execute(
-            deps.as_mut(),
-            env.clone(),
-            message_info(&executor, &[]),
-            SchedulerExecuteMsg::Execute(vec![Uint64::new(156434254)]),
-        )
-        .unwrap();
-
-        assert_eq!(
-            response.messages,
-            vec![
-                SubMsg::reply_never(
-                    Contract(Addr::unchecked("pair-0")).call(
-                        to_json_binary(&ExecuteMsg::Order((
-                            vec![(side.clone(), Price::Fixed(price), None)],
-                            None,
-                        )))
-                        .unwrap(),
-                        vec![],
-                    )
-                ),
-                SubMsg::reply_never(BankMsg::Send {
-                    to_address: executor.to_string(),
-                    amount: vec![Coin::new(21312u128, "rune")],
-                }),
-                SubMsg::reply_on_error(
-                    WasmMsg::Execute {
-                        contract_addr: manager.to_string(),
-                        msg: to_json_binary(&ManagerExecuteMsg::Execute {
-                            contract_address: owner.clone(),
-                        })
-                        .unwrap(),
-                        funds: vec![],
-                    },
-                    0,
-                ),
-                SubMsg::reply_never(BankMsg::Send {
-                    to_address: executor.to_string(),
-                    amount: vec![remaining_rebate],
-                }),
-            ]
-        )
     }
 
     #[test]
@@ -1042,8 +609,6 @@ mod execute_trigger_tests {
 
 #[cfg(test)]
 mod filtered_triggers_tests {
-    use std::str::FromStr;
-
     use super::*;
 
     use calc_rs::{
@@ -1053,9 +618,8 @@ mod filtered_triggers_tests {
     use cosmwasm_std::{
         from_json,
         testing::{mock_dependencies, mock_env},
-        Addr, Decimal, Uint64,
+        Addr, Uint64,
     };
-    use rujira_rs::fin::Side;
 
     #[test]
     fn fetches_triggers_with_timestamp_filter() {
@@ -1280,221 +844,6 @@ mod filtered_triggers_tests {
                     execution_rebate: vec![],
                     executors: vec![],
                     jitter: None
-                })
-                .collect::<Vec<_>>()
-        );
-    }
-
-    #[test]
-    fn fetches_triggers_with_pair_only_limit_order_filter() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let owner = deps.api.addr_make("creator");
-
-        for i in 1..=10 {
-            TRIGGERS
-                .save(
-                    deps.as_mut().storage,
-                    &Trigger {
-                        id: Uint64::from(i as u64),
-                        owner: owner.clone(),
-                        contract_address: Addr::unchecked("manager"),
-                        msg: Binary::default(),
-                        condition: Condition::FinLimitOrderFilled {
-                            owner: Some(Addr::unchecked("owner")),
-                            pair_address: Addr::unchecked(format!("pair-{}", i % 2)),
-                            side: Side::Base,
-                            price: Decimal::from_str(&i.to_string()).unwrap(),
-                        },
-                        execution_rebate: vec![],
-                        executors: vec![],
-                        jitter: None,
-                    },
-                )
-                .unwrap();
-        }
-
-        let response = from_json::<Vec<Trigger>>(
-            query(
-                deps.as_ref(),
-                env.clone(),
-                SchedulerQueryMsg::Filtered {
-                    filter: ConditionFilter::LimitOrder {
-                        pair_address: Addr::unchecked("pair-0"),
-                        price_range: None,
-                    },
-                    limit: None,
-                },
-            )
-            .unwrap(),
-        )
-        .unwrap();
-
-        (2..=5)
-            .map(|i| {
-                let j = i * 2;
-                Trigger {
-                    id: Uint64::from(j as u64),
-                    owner: owner.clone(),
-                    contract_address: Addr::unchecked("manager"),
-                    msg: Binary::default(),
-                    condition: Condition::FinLimitOrderFilled {
-                        owner: Some(Addr::unchecked("owner")),
-                        pair_address: Addr::unchecked("pair-0"),
-                        side: Side::Base,
-                        price: Decimal::from_str(&j.to_string()).unwrap(),
-                    },
-                    execution_rebate: vec![],
-                    executors: vec![],
-                    jitter: None,
-                }
-            })
-            .collect::<Vec<_>>()
-            .iter()
-            .for_each(|t| assert!(response.contains(t)));
-    }
-
-    #[test]
-    fn fetches_triggers_with_pair_and_price_range_limit_order_filter() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let owner = deps.api.addr_make("creator");
-
-        for i in 1..=10 {
-            TRIGGERS
-                .save(
-                    deps.as_mut().storage,
-                    &Trigger {
-                        id: Uint64::from(i as u64),
-                        owner: owner.clone(),
-                        msg: Binary::default(),
-                        contract_address: Addr::unchecked("manager"),
-                        condition: Condition::FinLimitOrderFilled {
-                            owner: Some(Addr::unchecked("owner")),
-                            pair_address: Addr::unchecked(format!("pair-{}", i % 2)),
-                            side: Side::Base,
-                            price: Decimal::from_str(&i.to_string()).unwrap(),
-                        },
-                        execution_rebate: vec![],
-                        executors: vec![],
-                        jitter: None,
-                    },
-                )
-                .unwrap();
-        }
-
-        let response = from_json::<Vec<Trigger>>(
-            query(
-                deps.as_ref(),
-                env.clone(),
-                SchedulerQueryMsg::Filtered {
-                    filter: ConditionFilter::LimitOrder {
-                        pair_address: Addr::unchecked("pair-0"),
-                        price_range: Some((
-                            Decimal::from_str("7.0").unwrap(),
-                            Decimal::from_str("9.0").unwrap(),
-                        )),
-                    },
-                    limit: None,
-                },
-            )
-            .unwrap(),
-        )
-        .unwrap();
-
-        assert_eq!(
-            response,
-            (4..=4)
-                .map(|i| {
-                    let j = i * 2;
-                    Trigger {
-                        id: Uint64::from(j as u64),
-                        owner: owner.clone(),
-                        contract_address: Addr::unchecked("manager"),
-                        msg: Binary::default(),
-                        condition: Condition::FinLimitOrderFilled {
-                            owner: Some(Addr::unchecked("owner")),
-                            pair_address: Addr::unchecked("pair-0"),
-                            side: Side::Base,
-                            price: Decimal::from_str(&j.to_string()).unwrap(),
-                        },
-                        execution_rebate: vec![],
-                        executors: vec![],
-                        jitter: None,
-                    }
-                })
-                .collect::<Vec<_>>()
-        );
-    }
-
-    #[test]
-    fn fetches_triggers_with_limit_order_filter_and_limit() {
-        let mut deps = mock_dependencies();
-        let env = mock_env();
-        let owner = deps.api.addr_make("creator");
-
-        for i in 1..=10 {
-            TRIGGERS
-                .save(
-                    deps.as_mut().storage,
-                    &Trigger {
-                        id: Uint64::from(i as u64),
-                        owner: owner.clone(),
-                        contract_address: Addr::unchecked("manager"),
-                        msg: Binary::default(),
-                        condition: Condition::FinLimitOrderFilled {
-                            owner: Some(Addr::unchecked("owner")),
-                            pair_address: Addr::unchecked(format!("pair-{}", i % 2)),
-                            side: Side::Base,
-                            price: Decimal::from_str(&i.to_string()).unwrap(),
-                        },
-                        execution_rebate: vec![],
-                        executors: vec![],
-                        jitter: None,
-                    },
-                )
-                .unwrap();
-        }
-
-        let response = from_json::<Vec<Trigger>>(
-            query(
-                deps.as_ref(),
-                env.clone(),
-                SchedulerQueryMsg::Filtered {
-                    filter: ConditionFilter::LimitOrder {
-                        pair_address: Addr::unchecked("pair-0"),
-                        price_range: Some((
-                            Decimal::from_str("1.0").unwrap(),
-                            Decimal::from_str("9.0").unwrap(),
-                        )),
-                    },
-                    limit: Some(1),
-                },
-            )
-            .unwrap(),
-        )
-        .unwrap();
-
-        assert_eq!(
-            response,
-            (1..=1)
-                .map(|i| {
-                    let j = i * 2;
-                    Trigger {
-                        id: Uint64::from(j as u64),
-                        owner: owner.clone(),
-                        contract_address: Addr::unchecked("manager"),
-                        msg: Binary::default(),
-                        condition: Condition::FinLimitOrderFilled {
-                            owner: Some(Addr::unchecked("owner")),
-                            pair_address: Addr::unchecked("pair-0"),
-                            side: Side::Base,
-                            price: Decimal::from_str(&j.to_string()).unwrap(),
-                        },
-                        execution_rebate: vec![],
-                        executors: vec![],
-                        jitter: None,
-                    }
                 })
                 .collect::<Vec<_>>()
         );

--- a/packages/calc-rs/src/conditions/condition.rs
+++ b/packages/calc-rs/src/conditions/condition.rs
@@ -15,7 +15,6 @@ use crate::{
         limit_orders::fin_limit_order::{Direction, FinLimitOrder, PriceStrategy},
         swaps::swap::Swap,
     },
-    cadence::Cadence,
     conditions::{asset_value_ratio::AssetValueRatio, schedule::Schedule},
     manager::{Affiliate, ManagerQueryMsg, Strategy, StrategyStatus},
     operation::{Operation, StatefulOperation},
@@ -55,10 +54,7 @@ impl Condition {
         match self {
             Condition::TimestampElapsed(_) => 1,
             Condition::BlocksCompleted(_) => 1,
-            Condition::Schedule(schedule) => match schedule.cadence {
-                Cadence::LimitOrder { .. } => 4,
-                _ => 2,
-            },
+            Condition::Schedule(_) => 2,
             Condition::CanSwap { .. } => 2,
             Condition::FinLimitOrderFilled { .. } => 2,
             Condition::BalanceAvailable { .. } => 1,
@@ -72,11 +68,7 @@ impl Condition {
         Ok(match self {
             Condition::TimestampElapsed(timestamp) => env.block.time >= *timestamp,
             Condition::BlocksCompleted(height) => env.block.height >= *height,
-            Condition::Schedule(schedule) => {
-                schedule
-                    .cadence
-                    .is_due(deps, env, &schedule.scheduler_address)?
-            }
+            Condition::Schedule(schedule) => schedule.cadence.is_due(deps, env)?,
             Condition::FinLimitOrderFilled {
                 owner,
                 pair_address,

--- a/packages/calc-rs/src/conditions/schedule.rs
+++ b/packages/calc-rs/src/conditions/schedule.rs
@@ -39,9 +39,9 @@ impl Schedule {
             })?;
         }
 
-        let (condition, schedule) = if self.cadence.is_due(deps, env, &self.scheduler_address)? {
-            let current = self.cadence.clone().crank(deps, env)?;
-            let condition = current.into_condition(deps, env, &self.scheduler_address)?;
+        let (condition, schedule) = if self.cadence.is_due(deps, env)? {
+            let current = self.cadence.clone().crank(env)?;
+            let condition = current.into_condition(env)?;
             (
                 condition,
                 Schedule {
@@ -50,9 +50,7 @@ impl Schedule {
                 },
             )
         } else {
-            let condition = self
-                .cadence
-                .into_condition(deps, env, &self.scheduler_address)?;
+            let condition = self.cadence.into_condition(env)?;
             (condition, self)
         };
 

--- a/packages/calc-rs/src/scheduler.rs
+++ b/packages/calc-rs/src/scheduler.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Binary, Coin, Decimal, StdError, StdResult, Timestamp, Uint64};
+use cosmwasm_std::{Addr, Binary, Coin, StdError, StdResult, Timestamp, Uint64};
 
 use crate::conditions::condition::Condition;
 
@@ -90,10 +90,6 @@ pub enum ConditionFilter {
     BlockHeight {
         start: Option<u64>,
         end: Option<u64>,
-    },
-    LimitOrder {
-        pair_address: Addr,
-        price_range: Option<(Decimal, Decimal)>,
     },
 }
 

--- a/tests/src/strategy_handler.rs
+++ b/tests/src/strategy_handler.rs
@@ -86,16 +86,6 @@ impl<'a> StrategyHandler<'a> {
             )
             .unwrap();
 
-        self.harness
-            .execute_filtered_triggers(
-                &self.keeper,
-                ConditionFilter::LimitOrder {
-                    pair_address: self.harness.fin_addr.clone(),
-                    price_range: None,
-                },
-            )
-            .unwrap();
-
         self
     }
 


### PR DESCRIPTION
Refactor cadence handling by removing LimitOrder variant and related logic

- Removed the LimitOrder variant from the Cadence enum and its associated logic in the is_due, into_condition, and crank methods.
- Updated the Condition enum to eliminate references to LimitOrder cadence.
- Refactored Schedule and Condition implementations to accommodate the removal of LimitOrder.
- Cleaned up integration tests by removing tests related to LimitOrder cadence.