### PR TITLE
Allow schedules to be leaf nodes

### DIFF
--- a/contracts/strategy/src/state.rs
+++ b/contracts/strategy/src/state.rs
@@ -1,4 +1,5 @@
 use calc_rs::{
+    conditions::condition::Condition,
     constants::MAX_STRATEGY_SIZE,
     manager::Affiliate,
     operation::Operation,
@@ -52,14 +53,20 @@ impl NodeStore {
                     }
                 }
                 Node::Condition {
+                    ref condition,
                     on_success,
                     on_failure,
                     ..
                 } => {
                     if on_failure.is_none() && on_success.is_none() {
-                        return Err(StdError::generic_err(
-                            "Condition node must have at least one branch defined",
-                        ));
+                        match condition {
+                            Condition::Schedule(_) => {}
+                            _ => {
+                                return Err(StdError::generic_err(
+                                    "Condition nodes must have at least one branch defined",
+                                ));
+                            }
+                        }
                     }
 
                     if let Some(on_success) = on_success {


### PR DESCRIPTION
Schedules have side effects, so we allow then to be a leaf node rather than merely a control flow one